### PR TITLE
fix(rust-job): copy-edit, active voice AND feat(rust-job): add APPLICATION field

### DIFF
--- a/.github/ISSUE_TEMPLATE/rust-job.md
+++ b/.github/ISSUE_TEMPLATE/rust-job.md
@@ -7,31 +7,30 @@ assignees: ''
 
 ---
 
-__COMPANY__: [Company name; optionally link to your company's website or careers page.]
+__ORGANIZATION/COMPANY__: [Organization (e.g. company) name; optionally link to your organization's website or careers page.]
 
 __TYPE__: [Full time, part time, internship, contract, etc.]
 
-__LOCATION__: [Where are your office or offices located? If your workplace language isn't English-speaking, please specify it.]
+__LOCATION__: [Where are your office or offices located? If your workplace language is not English-speaking, please specify it.]
 
-__REMOTE__: [Do you offer the option of working remotely? Please state clearly if remote work is restricted to certain regions or time zones, or if availability within a certain time of day is expected or required.]
+__REMOTE__: [Do you offer the option of working remotely? Please state if you restrict remote work to certain regions or time zones, or if you expect or require availability within a certain time of day.]
 
-__VISA__: [Does your company sponsor visas?]
+__VISA__: [Does your organization sponsor visas?]
 
-__DESCRIPTION__: [What does your company do, and what are you using Rust for? How much experience are you seeking and what seniority levels are you hiring for? The more details the better.]
+__DESCRIPTION__: [What does your organization do, and what are you using Rust for? How much experience are you seeking and what seniority levels are you hiring for? The more relevant details for the job, the better.]
 
-__ESTIMATED COMPENSATION__: [Be courteous to your potential future colleagues by attempting to provide at least a rough expectation of wages/salary.
+__ESTIMATED COMPENSATION__: [Provide at least a rough expectation of wages/salary, as a courteous behavior to your potential future colleagues.]
 
-If you are listing several positions in the "Description" field above, then feel free to include this information inline above, and put "See above" in this field.
+If you are listing multiple positions in the "Description" field above, then feel free to include this information inline above, and put "See above" in this field.
 
 If compensation is negotiable, please attempt to provide at least a base estimate from which to begin negotiations. If compensation is highly variable, then feel free to provide a range.
 
-If compensation is expected to be offset by other benefits, then please include that information here as well. If you don't have firm numbers but do have relative expectations of candidate expertise (e.g. entry-level, senior), then you may include that here.
-If you truly have no information, then put "Uncertain" here.
+If you expect compensation to be offset by other benefits, then include that information as well. If you do not have firm numbers, but do have relative expectations of candidate expertise (e.g. entry-level, senior), then you may include that. If you truly have no information, then put "Uncertain" here.
 
-Note that some jurisdictions (e.g., California, Colorado, New York City) currently or will soon require salary ranges on job postings by law. If your company is based in one of these locations or you plan to hire employees who reside in any of these locations, you are likely subject to these laws. Other jurisdictions may require salary information to be available upon request or be provided after the first interview. To avoid issues, we recommend all postings provide salary information.
+Note that some jurisdictions (e.g. United States' jurisdictions of California, Colorado, and New York City) require salary ranges on job postings. If your organization is in one of these locations or you plan to hire employees who reside in any of these locations, you are likely subject to these laws. Other jurisdictions may require salary information to be available upon request or that you provide it after the first interview. To avoid issues, we recommend all postings to provide salary information.
 
-You must state clearly in your posting if you are planning to compensate employees partially or fully in something other than fiat currency (e.g. cryptocurrency, stock options, equity, etc).
+You must state in your posting if you are planning to compensate employees partially or fully in something other than fiat currency (e.g. cryptocurrency, stock options, equity, etc).
 
 Do not put just "Uncertain" in this case as the default assumption is that the compensation will be 100% fiat.
 
-Postings that fail to comply with this addendum will be removed. Thank you.]
+[rustgig](https://github.com/rustgig) team will remove postings that fail to comply with this addendum. Thank you.]

--- a/.github/ISSUE_TEMPLATE/rust-job.md
+++ b/.github/ISSUE_TEMPLATE/rust-job.md
@@ -21,6 +21,8 @@ __DESCRIPTION__: [What does your organization do, and what are you using Rust fo
 
 __ESTIMATED COMPENSATION__: [Provide at least a rough expectation of wages/salary, as a courteous behavior to your potential future colleagues.]
 
+__APPLICATION__: [Ideally include e-mail address contact for the candidate to apply for the job, but you may also add other application mediums such as forms.]
+
 If you are listing multiple positions in the "Description" field above, then feel free to include this information inline above, and put "See above" in this field.
 
 If compensation is negotiable, please attempt to provide at least a base estimate from which to begin negotiations. If compensation is highly variable, then feel free to provide a range.


### PR DESCRIPTION
### Description of changes

Initially, just some few copy edits including active voice, and adding an application/contact field which I see many posts on https://reddit.com/r/rust/comments/13yx1dn do.

### Additional comments

In the future, I want to turn this into a more precise template for those looking for jobs following an example from a company using Rust I saw before (if I remember correctly, they call it performance application or similar that as to state clearly what the candidate must do on the jobs, what will likely use like technologies/architectures, requirements, etc, instead of solely focusing on experience level / seniority).

### CC
@nohsheef 